### PR TITLE
Improve evaluation data loading throughput

### DIFF
--- a/extract_features.py
+++ b/extract_features.py
@@ -106,7 +106,7 @@ def extract_features(model, dataloader, device):
     
     with torch.no_grad():
         for images, labels in tqdm(dataloader, desc="Extracting features"):
-            images = images.to(device)
+            images = images.to(device, non_blocking=True)
             
             # Forward pass - this will return features before the classifier
             features = model(images)


### PR DESCRIPTION
## Summary
- apply evaluation and training transforms inside dataset `__getitem__` to leverage DataLoader workers and simplify collates
- tune the evaluation `DataLoader` parameters and switch host-to-device copies to `non_blocking=True` during training/eval
- use non-blocking GPU transfers while extracting features

## Testing
- `python -m compileall data_utils.py train_classifier.py`
- `python -m compileall extract_features.py`


------
https://chatgpt.com/codex/tasks/task_e_68e25bcb0acc832aa5f2ceb9bb4073e2