### PR TITLE
Keep activation stat queues stable across compiled forwards

### DIFF
--- a/base.py
+++ b/base.py
@@ -101,11 +101,11 @@ class Classifier(nn.Module):
 
         return logits
 
-    def pop_stats(self) -> list:
+    def pop_stats(self, *, scalarize: bool = True) -> list:
         all_stats = []
         for blk in self.blocks:
             if hasattr(blk, "pop_stats"):
-                all_stats.extend(blk.pop_stats())
+                all_stats.extend(blk.pop_stats(scalarize=scalarize))
         return all_stats
     
 

--- a/preactresnet.py
+++ b/preactresnet.py
@@ -195,11 +195,11 @@ class PreActResNet(nn.Module):
 
         return x
 
-    def pop_stats(self):
+    def pop_stats(self, *, scalarize: bool = True):
         all_stats = []
         for module in self.modules():
             if isinstance(module, ConnLoggerMixin):
-                all_stats.extend(module.pop_stats())
+                all_stats.extend(module.pop_stats(scalarize=scalarize))
         return all_stats
 
 


### PR DESCRIPTION
## Summary
- avoid replacing the activation stat queue inside `ConnLoggerMixin.pop_stats`
- clear the cached metrics in place so compiled forwards keep reusing the same list object

## Testing
- python -m compileall train_classifier.py connect.py base.py preactresnet.py

------
https://chatgpt.com/codex/tasks/task_e_68e264979a74832a848cf594ccbd2e19